### PR TITLE
removed unused properties from modal download buttons

### DIFF
--- a/src/components/IconModal.vue
+++ b/src/components/IconModal.vue
@@ -30,7 +30,6 @@
               <a
                 :href="getIconSrc(icon.name, selectedVariant, 'svg').value"
                 class="uids-button"
-                :class="{ active: currentVariant == 'one-color' }"
                 v-if="getVariantFormat(selectedVariant, 'svg')"
                 download
               >
@@ -49,7 +48,6 @@
                   getIconSrc(icon.name, selectedVariant, 'png', 'square').value
                 "
                 class="uids-button"
-                :class="{ active: currentVariant == 'two-color' }"
                 v-if="getVariantFormat(selectedVariant, 'png')"
                 download
               >
@@ -68,7 +66,6 @@
                   getIconSrc(icon.name, selectedVariant, 'png', 'wide').value
                 "
                 class="uids-button"
-                :class="{ active: currentVariant == 'two-color' }"
                 v-if="getVariantFormat(selectedVariant, 'png')"
                 download
               >


### PR DESCRIPTION
Resolves https://github.com/uiowa/brand-icon-browser/issues/11

How to test
1. Check out `main`
2. Open a modal
3. Note the warnings that appear in the browser development console when clicking an icon in the list
4. check out fix-undefined-currentVariant branch
5. Open a modal
6. No more warnings? Fixed.