### PR TITLE
removed setCurrentSearch term prop from router-view

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -34,11 +34,7 @@
         />
       </div>
 
-      <router-view
-        @openModal="openModal"
-        :currentVariant="currentVariant"
-        @setCurrentSearchTerm="setCurrentSearchTerm"
-      />
+      <router-view @openModal="openModal" :currentVariant="currentVariant" />
     </main>
   </div>
 

--- a/src/components/IconModal.vue
+++ b/src/components/IconModal.vue
@@ -141,7 +141,6 @@ import getIconSrc from "../composables/getIconSrc.js";
 const props = defineProps({
   icon: Object,
   currentCategory: Object,
-  currentSearchTerm: String,
   variant: String,
 });
 


### PR DESCRIPTION
This was leftover from when SearchBar.vue was included in each view separately instead of App.vue, removed extra searchTerm prop from IconModal

Resolves https://github.com/uiowa/brand-icon-browser/issues/13

How to test

- Check out main
- Open the webapp
- Note the warnings that appear in the browser development console when clicking an icon in the list
- check out `fix-extraneous-non-emits-on-load`
- refresh/reload web app
- No more warnings? Fixed.