### PR TITLE
Target specific commit of brand-icons in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "core-js": "^3.8.3",
         "fs": "0.0.1-security",
         "sharp": "^0.30.5",
-        "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#module",
+        "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#ab13a3f",
         "vue": "^3.2.13",
         "vue-router": "^4.0.3",
         "vue-toggle-component": "^1.0.16"


### PR DESCRIPTION
Resolves: https://github.com/uiowa/brand-icon-browser/issues/18

> Until proper releases on brand-icons are set up, my proposed solution is that I'm going to target individual commits, but for now this needs to not be targeted at an older branch.