### PR TITLE
Load SVG files in main icon list, fixes a regression that was forcing PNGs to render in the list.

### DIFF
--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -2,7 +2,8 @@
   <img
     :icon="icon"
     :variant="variant"
-    :src="getIconSrc(icon, variant).value"
+    :format="format"
+    :src="getIconSrc(icon, variant, format).value"
     :alt="icon"
     loading="lazy"
     :class="variant"

--- a/src/components/IconList.vue
+++ b/src/components/IconList.vue
@@ -8,7 +8,7 @@
       :to="{ hash: '#' + icon.name }"
       @click="openModal(icon)"
     >
-      <Icon :icon="icon.name" :variant="variant" />
+      <Icon :icon="icon.name" :variant="variant" format="svg" />
       <span class="icon-list__label">{{ icon.name }}</span>
     </router-link>
   </div>


### PR DESCRIPTION
After refactoring some of the code that fetches different variants and formats of images, the `IconList` component was pulling in PNG files, but I prefer rendering SVGs in the IconList component.