### PR TITLE
Updated uiowa-brand-icons package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "fs": "0.0.1-security",
                 "sharp": "^0.30.5",
                 "uids": "git+https://github.com/uiowa/uids.git#233d61a",
-                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#ab13a3f",
+                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#802ad2b",
                 "vue": "^3.2.13",
                 "vue-router": "^4.0.3",
                 "vue-toggle-component": "^1.0.16"
@@ -9727,8 +9727,7 @@
         },
         "node_modules/uiowa-brand-icons": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#ab13a3f354092b6d703427068d500d1cfb2b9c17",
-            "integrity": "sha512-/igDmqT25YSy4OjVhWJ+ICInhHRjHRvqay6+0jVtB7BQ4ZltqezOm/jcPLwuzKgL7QijzwsFTOLznVA5u4hcjw=="
+            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#802ad2bb3b56eea13c9f439748f2b299a307f31f"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -17907,14 +17906,15 @@
         },
         "uids": {
             "version": "git+ssh://git@github.com/uiowa/uids.git#233d61a653dba35df25f7a77b8ef4560bfe71cf1",
+            "integrity": "sha512-Gy3riSXMyEk5tzdaiWQHDEwETl3uLqE6mTjVsdZxTkfhOt+F+m18o2zaYf+u17Gu3OormuAebXoFaxy5U0HFlA==",
             "from": "uids@git+https://github.com/uiowa/uids.git#233d61a",
             "requires": {
                 "vue": "^3.2.31"
             }
         },
         "uiowa-brand-icons": {
-            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#ab13a3f354092b6d703427068d500d1cfb2b9c17",
-            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#ab13a3f"
+            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#802ad2bb3b56eea13c9f439748f2b299a307f31f",
+            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#802ad2b"
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "fs": "0.0.1-security",
         "sharp": "^0.30.5",
         "uids": "git+https://github.com/uiowa/uids.git#233d61a",
-        "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#ab13a3f",
+        "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#802ad2b",
         "vue": "^3.2.13",
         "vue-router": "^4.0.3",
         "vue-toggle-component": "^1.0.16"


### PR DESCRIPTION
This should resolve https://github.com/uiowa/brand-icon-browser/issues/29 as well as provide the correct color profile for the icons.