### PR TITLE
Clean up getIconSrc composable, switch back icon list to use PNGs

### DIFF
--- a/src/components/IconList.vue
+++ b/src/components/IconList.vue
@@ -8,12 +8,17 @@
       :to="{ hash: '#' + icon.name }"
       @click="openModal(icon)"
     >
-      <Icon :icon="icon.name" :variant="variant" format="svg" />
+      <Icon :icon="icon.name" :variant="variant" />
       <span class="icon-list__label">{{ icon.name }}</span>
     </router-link>
   </div>
   <div class="content text-center" v-if="icons.length == 0">
-    <Icon icon="heart-break" variant="two-color" class="not-found-icon" />
+    <Icon
+      icon="heart-break"
+      format="svg"
+      variant="two-color"
+      class="not-found-icon"
+    />
     <p>No icons found.</p>
   </div>
 </template>

--- a/src/composables/getIconSrc.js
+++ b/src/composables/getIconSrc.js
@@ -1,63 +1,21 @@
-import {ref} from "vue";
+import { ref } from "vue";
 
-const getIconSrc = (icon, variant, format, ratio) => { // console.log(icon + ' ' + variant + ' ' + format + ' ')
-    const currentIcon = ref("");
+const getIconSrc = (icon, variant, format, ratio) => {
+  const currentIcon = ref("");
 
-    if (format) {
-        if (ratio) {
-            currentIcon.value = "/brand-icons/" + icon + "-" + variant + "-" + ratio + "." + format;
-        } else {
-            currentIcon.value = "/brand-icons/" + icon + "-" + variant + "." + format;
-        }
-    } else { // fallback to png versions if no format provided
-        currentIcon.value = "/brand-icons/" + icon + "-" + variant + ".png"
+  if (format) {
+    if (ratio) {
+      currentIcon.value =
+        "/brand-icons/" + icon + "-" + variant + "-" + ratio + "." + format;
+    } else {
+      currentIcon.value = "/brand-icons/" + icon + "-" + variant + "." + format;
     }
+  } else {
+    // if no format is provided, fallback to png
+    currentIcon.value = "/brand-icons/" + icon + "-" + variant + ".png";
+  }
 
-
-    return currentIcon;
-}
-
-// Old stuff for reference:
-
-// const getIconSrc = (icon, variant, format) => {
-//     // This could be cleaned up signficantly if the icons were in the filesystem in a more consistent way, ex:
-//     // - icon-two-color.svg
-//     // - icon-two-color.png
-//     // - icon-black.svg
-//     // - icon-black.png
-//     // - icon-white.svg
-//     // - icon-white.png
-//     // - icon-gold.svg
-//     // - icon-gold.png
-//     // Right now the code below is respecting the current file structure:
-//     const currentIcon = ref("");
-
-//     if (variant == "one-color") {
-//         if (format) {
-//             if (format == "png") {
-//                 currentIcon.value = "/brand-icons/" + icon + "-BLACK." + format;
-//             } else {
-//                 currentIcon.value = "/brand-icons/" + icon + "." + format;
-//             }
-
-//         } else {
-//             currentIcon.value = "/brand-icons/" + icon + ".svg";
-//         }
-//     } else if (variant == "two-color") {
-//         if (format) {
-//             currentIcon.value = "/brand-icons/" + icon + "-" + variant + "." + format;
-//         } else {
-//             currentIcon.value = "/brand-icons/" + icon + "-" + variant + ".svg";
-//         }
-//     } else if (variant == "gold") {
-//         currentIcon.value = "/brand-icons/" + icon + "-GOLD.png";
-//     } else if (variant == "white") {
-//         currentIcon.value = "/brand-icons/" + icon + "-REVERSED.png";
-//     } else {
-//         currentIcon.value = "/brand-icons/" + icon + "-" + variant + ".svg";
-//     }
-
-//     return currentIcon;
-// };
+  return currentIcon;
+};
 
 export default getIconSrc;


### PR DESCRIPTION
SVGs were looking "jaggedy" / had bad aliasing on lower DPI screens:

![Screen Shot 2022-06-02 at 9 58 47 AM](https://user-images.githubusercontent.com/472923/171674666-0eaadcbc-99be-45bc-9b38-c62d8eaa4cda.png)

This switches us back to presenting PNGs instead.