### PR TITLE
search bar mobile style touchups and fixes #35

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -85,13 +85,16 @@ a {
   padding: 15px 0;
   background-color: #f5f5f5de;
   backdrop-filter: blur(5px);
-  display: flex;
-  justify-content: start;
-  align-items: center;
+
+  @media only screen and (min-width: 760px) {
+    display: flex;
+    justify-content: start;
+    align-items: center;
+  }
 }
 
 .sticky {
-  @media only screen and (min-width: 1280px) {
+  @media only screen and (min-width: 760px) {
     position: sticky;
     top: 0;
   }

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -71,7 +71,7 @@ function setCurrentSearchTerm(term) {
     justify-content: center;
     align-items: center;
   }
-  &__input {
+  &__input[type="search"] {
     display: block;
     margin: 0;
     border: 1px solid #ccc;
@@ -80,15 +80,22 @@ function setCurrentSearchTerm(term) {
     width: 100%;
     height: 60px;
     font-size: 1.3rem;
+    border-radius: 0;
+    -webkit-appearance: none;
+    background: white;
     &:focus {
       z-index: 1;
     }
   }
-
+  // Hide default mobile Safari search icons
+  &__input[type="search"]::-webkit-search-decoration,
+  &__input[type="search"]::-webkit-search-results-decoration {
+    display: none;
+  }
   &__button {
     color: black;
     background: white;
-    padding: 0 20px;
+    padding: 0 5px;
     border-left: 0;
     border-top: 1px solid #ccc;
     border-right: 1px solid #ccc;
@@ -97,15 +104,14 @@ function setCurrentSearchTerm(term) {
     font-size: 1.3rem;
     height: 60px;
     cursor: pointer;
+
+    @media only screen and (min-width: 760px) {
+      padding: 0 20px;
+    }
     svg {
       display: block;
       width: 40px;
     }
   }
-}
-// Hide default mobile Safari search icons
-input[type="search"]::-webkit-search-decoration,
-input[type="search"]::-webkit-search-results-decoration {
-  display: none;
 }
 </style>

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="button-group settings__variant-selector">
+  <div class="settings__variant-selector">
     <vue-toggle
       activeColor="#ffcd00"
       title="Color"
@@ -11,7 +11,6 @@
 </template>
 
 <script setup>
-import ButtonGroup from "@/components/ButtonGroup.vue";
 import Icon from "@/components/Icon.vue";
 import { defineProps } from "vue";
 import VueToggle from "vue-toggle-component";
@@ -31,8 +30,13 @@ function toggleVariantColor() {
 <style lang="scss">
 .settings {
   &__variant-selector {
-    margin-left: auto;
-    padding: 0 20px;
+    margin: auto;
+    padding-top: 10px;
+    padding-bottom: 0;
+    @media only screen and (min-width: 760px) {
+      margin-left: auto;
+      padding: 0 20px;
+    }
     .m-toggle__content {
       background: #d7d7d7;
       border: 1px solid #bab8b8;


### PR DESCRIPTION
Resolves #35 

Before:
<img width="371" alt="Screen Shot 2022-06-03 at 8 48 14 AM" src="https://user-images.githubusercontent.com/472923/171867056-be633494-0296-4076-be77-68cc536f65d4.png">


After:
<img width="374" alt="Screen Shot 2022-06-03 at 8 46 48 AM" src="https://user-images.githubusercontent.com/472923/171866867-f9b1eba7-1efa-4bad-9c5c-c2fb8f6c6409.png">

Still not perfect, but not completely broken 