### PR TITLE
Icon preview modal adjustments

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -66,6 +66,11 @@ body {
   background-color: #f5f5f5;
   text-rendering: optimizeLegibility;
   scroll-behavior: smooth;
+
+  &.modal-open {
+    height: 100vh;
+    overflow: hidden;
+  }
 }
 
 a {
@@ -236,6 +241,7 @@ function setCurrentSearchTerm(term) {
 
 function openModal(icon) {
   showModal.value = true;
+  document.body.classList.add("modal-open");
   iconDetails.value = icon;
 }
 
@@ -253,6 +259,7 @@ function toggleVariantColor() {
 
 function closeModal() {
   router.push({ hash: "" });
+  document.body.classList.remove("modal-open");
   showModal.value = false;
 }
 </script>

--- a/src/components/IconModal.vue
+++ b/src/components/IconModal.vue
@@ -16,110 +16,115 @@
           />
         </svg>
       </div>
-      <div class="modal__icon-preview-wrapper">
-        <div>
-          <div class="icon-preview" :class="iconPreviewClass">
-            <Icon
-              :icon="icon.name"
-              :variant="selectedVariant"
-              class="icon-preview__img"
-            />
-          </div>
-        </div>
-        <div class="modal__preview-actions">
+      <div class="modal__body">
+        <div class="modal__icon-preview-wrapper">
           <div>
-            <h1 class="modal__heading">{{ icon.name }}</h1>
-            <p class="text-center">Select a variant:</p>
-            <div class="modal__icon-variants-wrapper">
-              <div
-                v-for="value in variantFormats"
-                class="icon-preview icon-preview--small"
-                :class="[
-                  { active: selectedVariant == value.variant },
-                  'icon-preview--' + value.variant,
-                ]"
-                :key="value.variant"
-              >
-                <Icon
-                  class="icon-preview__img"
-                  :icon="icon.name"
-                  :variant="value.variant"
-                  @click="changeSelectedVariant(value.variant)"
-                />
+            <div class="icon-preview" :class="iconPreviewClass">
+              <Icon
+                :icon="icon.name"
+                :variant="selectedVariant"
+                class="icon-preview__img"
+              />
+            </div>
+          </div>
+          <div class="modal__preview-actions">
+            <div>
+              <h1 class="modal__heading">{{ icon.name }}</h1>
+              <p class="text-center">Select a variant:</p>
+              <div class="modal__icon-variants-wrapper">
+                <div
+                  v-for="value in variantFormats"
+                  class="icon-preview icon-preview--small"
+                  :class="[
+                    { active: selectedVariant == value.variant },
+                    'icon-preview--' + value.variant,
+                  ]"
+                  :key="value.variant"
+                >
+                  <Icon
+                    class="icon-preview__img"
+                    :icon="icon.name"
+                    :variant="value.variant"
+                    @click="changeSelectedVariant(value.variant)"
+                  />
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-      <div class="icon-preview__download">
-        <a
-          :href="getIconSrc(icon.name, selectedVariant, 'svg').value"
-          class="uids-button"
-          v-if="getVariantFormat(selectedVariant, 'svg')"
-          download
-        >
-          <div class="uids-button__inner">
-            <span>SVG</span>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">
-              <!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
-              <path
-                d="M144 480C64.47 480 0 415.5 0 336C0 273.2 40.17 219.8 96.2 200.1C96.07 197.4 96 194.7 96 192C96 103.6 167.6 32 256 32C315.3 32 367 64.25 394.7 112.2C409.9 101.1 428.3 96 448 96C501 96 544 138.1 544 192C544 204.2 541.7 215.8 537.6 226.6C596 238.4 640 290.1 640 352C640 422.7 582.7 480 512 480H144zM303 392.1C312.4 402.3 327.6 402.3 336.1 392.1L416.1 312.1C426.3 303.6 426.3 288.4 416.1 279C407.6 269.7 392.4 269.7 383 279L344 318.1V184C344 170.7 333.3 160 320 160C306.7 160 296 170.7 296 184V318.1L256.1 279C247.6 269.7 232.4 269.7 223 279C213.7 288.4 213.7 303.6 223 312.1L303 392.1z"
-              />
-            </svg>
+        <div class="modal__icon-preview-wrapper">
+          <div class="icon-preview__download">
+            <a
+              :href="getIconSrc(icon.name, selectedVariant, 'svg').value"
+              class="uids-button"
+              v-if="getVariantFormat(selectedVariant, 'svg')"
+              download
+            >
+              <div class="uids-button__inner">
+                <span>SVG</span>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">
+                  <!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+                  <path
+                    d="M144 480C64.47 480 0 415.5 0 336C0 273.2 40.17 219.8 96.2 200.1C96.07 197.4 96 194.7 96 192C96 103.6 167.6 32 256 32C315.3 32 367 64.25 394.7 112.2C409.9 101.1 428.3 96 448 96C501 96 544 138.1 544 192C544 204.2 541.7 215.8 537.6 226.6C596 238.4 640 290.1 640 352C640 422.7 582.7 480 512 480H144zM303 392.1C312.4 402.3 327.6 402.3 336.1 392.1L416.1 312.1C426.3 303.6 426.3 288.4 416.1 279C407.6 269.7 392.4 269.7 383 279L344 318.1V184C344 170.7 333.3 160 320 160C306.7 160 296 170.7 296 184V318.1L256.1 279C247.6 269.7 232.4 269.7 223 279C213.7 288.4 213.7 303.6 223 312.1L303 392.1z"
+                  />
+                </svg>
+              </div>
+            </a>
+            <a
+              :href="
+                getIconSrc(icon.name, selectedVariant, 'png', 'square').value
+              "
+              class="uids-button"
+              v-if="getVariantFormat(selectedVariant, 'png')"
+              download
+            >
+              <div class="uids-button__inner">
+                <span>PNG (1:1)</span>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">
+                  <!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+                  <path
+                    d="M144 480C64.47 480 0 415.5 0 336C0 273.2 40.17 219.8 96.2 200.1C96.07 197.4 96 194.7 96 192C96 103.6 167.6 32 256 32C315.3 32 367 64.25 394.7 112.2C409.9 101.1 428.3 96 448 96C501 96 544 138.1 544 192C544 204.2 541.7 215.8 537.6 226.6C596 238.4 640 290.1 640 352C640 422.7 582.7 480 512 480H144zM303 392.1C312.4 402.3 327.6 402.3 336.1 392.1L416.1 312.1C426.3 303.6 426.3 288.4 416.1 279C407.6 269.7 392.4 269.7 383 279L344 318.1V184C344 170.7 333.3 160 320 160C306.7 160 296 170.7 296 184V318.1L256.1 279C247.6 269.7 232.4 269.7 223 279C213.7 288.4 213.7 303.6 223 312.1L303 392.1z"
+                  />
+                </svg>
+              </div>
+            </a>
+            <a
+              :href="
+                getIconSrc(icon.name, selectedVariant, 'png', 'wide').value
+              "
+              class="uids-button"
+              v-if="getVariantFormat(selectedVariant, 'png')"
+              download
+            >
+              <div class="uids-button__inner">
+                <span>PNG (16:9)</span>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">
+                  <!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+                  <path
+                    d="M144 480C64.47 480 0 415.5 0 336C0 273.2 40.17 219.8 96.2 200.1C96.07 197.4 96 194.7 96 192C96 103.6 167.6 32 256 32C315.3 32 367 64.25 394.7 112.2C409.9 101.1 428.3 96 448 96C501 96 544 138.1 544 192C544 204.2 541.7 215.8 537.6 226.6C596 238.4 640 290.1 640 352C640 422.7 582.7 480 512 480H144zM303 392.1C312.4 402.3 327.6 402.3 336.1 392.1L416.1 312.1C426.3 303.6 426.3 288.4 416.1 279C407.6 269.7 392.4 269.7 383 279L344 318.1V184C344 170.7 333.3 160 320 160C306.7 160 296 170.7 296 184V318.1L256.1 279C247.6 269.7 232.4 269.7 223 279C213.7 288.4 213.7 303.6 223 312.1L303 392.1z"
+                  />
+                </svg>
+              </div>
+            </a>
           </div>
-        </a>
-        <a
-          :href="getIconSrc(icon.name, selectedVariant, 'png', 'square').value"
-          class="uids-button"
-          v-if="getVariantFormat(selectedVariant, 'png')"
-          download
-        >
-          <div class="uids-button__inner">
-            <span>PNG (1:1)</span>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">
-              <!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
-              <path
-                d="M144 480C64.47 480 0 415.5 0 336C0 273.2 40.17 219.8 96.2 200.1C96.07 197.4 96 194.7 96 192C96 103.6 167.6 32 256 32C315.3 32 367 64.25 394.7 112.2C409.9 101.1 428.3 96 448 96C501 96 544 138.1 544 192C544 204.2 541.7 215.8 537.6 226.6C596 238.4 640 290.1 640 352C640 422.7 582.7 480 512 480H144zM303 392.1C312.4 402.3 327.6 402.3 336.1 392.1L416.1 312.1C426.3 303.6 426.3 288.4 416.1 279C407.6 269.7 392.4 269.7 383 279L344 318.1V184C344 170.7 333.3 160 320 160C306.7 160 296 170.7 296 184V318.1L256.1 279C247.6 269.7 232.4 269.7 223 279C213.7 288.4 213.7 303.6 223 312.1L303 392.1z"
-              />
-            </svg>
-          </div>
-        </a>
-        <a
-          :href="getIconSrc(icon.name, selectedVariant, 'png', 'wide').value"
-          class="uids-button"
-          v-if="getVariantFormat(selectedVariant, 'png')"
-          download
-        >
-          <div class="uids-button__inner">
-            <span>PNG (16:9)</span>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">
-              <!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
-              <path
-                d="M144 480C64.47 480 0 415.5 0 336C0 273.2 40.17 219.8 96.2 200.1C96.07 197.4 96 194.7 96 192C96 103.6 167.6 32 256 32C315.3 32 367 64.25 394.7 112.2C409.9 101.1 428.3 96 448 96C501 96 544 138.1 544 192C544 204.2 541.7 215.8 537.6 226.6C596 238.4 640 290.1 640 352C640 422.7 582.7 480 512 480H144zM303 392.1C312.4 402.3 327.6 402.3 336.1 392.1L416.1 312.1C426.3 303.6 426.3 288.4 416.1 279C407.6 269.7 392.4 269.7 383 279L344 318.1V184C344 170.7 333.3 160 320 160C306.7 160 296 170.7 296 184V318.1L256.1 279C247.6 269.7 232.4 269.7 223 279C213.7 288.4 213.7 303.6 223 312.1L303 392.1z"
-              />
-            </svg>
-          </div>
-        </a>
-      </div>
-      <div class="tags">
-        <span
-          v-for="term in icon.keywords"
-          :key="term.id"
-          @click="closeModal()"
-        >
-          <router-link
-            class="uids-tag"
-            :to="{
-              name: 'Search',
-              params: { term: term },
-            }"
-            >#{{ term }}</router-link
+        </div>
+        <div class="tags">
+          <span
+            v-for="term in icon.keywords"
+            :key="term.id"
+            @click="closeModal()"
           >
-        </span>
+            <router-link
+              class="uids-tag"
+              :to="{
+                name: 'Search',
+                params: { term: term },
+              }"
+              >#{{ term }}</router-link
+            >
+          </span>
+        </div>
       </div>
-      <!-- <div class="modal__actions">
-        <button @click="closeModal()">Close</button>
-      </div> -->
     </div>
   </div>
 </template>
@@ -190,15 +195,20 @@ function closeModal(currentCategory, currentSearchTerm) {
 
 <style lang="scss">
 .modal {
-  height: 100vh;
   width: 75%;
-  overflow-y: scroll;
+
   padding: 30px;
   padding-top: 20px;
   margin: 20px auto;
   background: #fff;
   border-radius: 4px;
   border: 1px solid #ccc;
+
+  &__body {
+    //height: 80vh;
+    max-height: calc(100vh - 200px);
+    overflow-y: auto;
+  }
 
   @media only screen and (min-width: 768px) {
     margin: 100px auto;
@@ -327,6 +337,5 @@ function closeModal(currentCategory, currentSearchTerm) {
 
 .tags {
   margin-top: 20px;
-  text-align: center;
 }
 </style>

--- a/src/components/IconModal.vue
+++ b/src/components/IconModal.vue
@@ -25,85 +25,81 @@
               class="icon-preview__img"
             />
           </div>
-          <div class="icon-preview__download">
-            <div class="button-group">
-              <a
-                :href="getIconSrc(icon.name, selectedVariant, 'svg').value"
-                class="uids-button"
-                v-if="getVariantFormat(selectedVariant, 'svg')"
-                download
-              >
-                <div class="uids-button__inner">
-                  <span>SVG</span>
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">
-                    <!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
-                    <path
-                      d="M144 480C64.47 480 0 415.5 0 336C0 273.2 40.17 219.8 96.2 200.1C96.07 197.4 96 194.7 96 192C96 103.6 167.6 32 256 32C315.3 32 367 64.25 394.7 112.2C409.9 101.1 428.3 96 448 96C501 96 544 138.1 544 192C544 204.2 541.7 215.8 537.6 226.6C596 238.4 640 290.1 640 352C640 422.7 582.7 480 512 480H144zM303 392.1C312.4 402.3 327.6 402.3 336.1 392.1L416.1 312.1C426.3 303.6 426.3 288.4 416.1 279C407.6 269.7 392.4 269.7 383 279L344 318.1V184C344 170.7 333.3 160 320 160C306.7 160 296 170.7 296 184V318.1L256.1 279C247.6 269.7 232.4 269.7 223 279C213.7 288.4 213.7 303.6 223 312.1L303 392.1z"
-                    />
-                  </svg>
-                </div>
-              </a>
-              <a
-                :href="
-                  getIconSrc(icon.name, selectedVariant, 'png', 'square').value
-                "
-                class="uids-button"
-                v-if="getVariantFormat(selectedVariant, 'png')"
-                download
-              >
-                <div class="uids-button__inner">
-                  <span>PNG (1:1)</span>
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">
-                    <!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
-                    <path
-                      d="M144 480C64.47 480 0 415.5 0 336C0 273.2 40.17 219.8 96.2 200.1C96.07 197.4 96 194.7 96 192C96 103.6 167.6 32 256 32C315.3 32 367 64.25 394.7 112.2C409.9 101.1 428.3 96 448 96C501 96 544 138.1 544 192C544 204.2 541.7 215.8 537.6 226.6C596 238.4 640 290.1 640 352C640 422.7 582.7 480 512 480H144zM303 392.1C312.4 402.3 327.6 402.3 336.1 392.1L416.1 312.1C426.3 303.6 426.3 288.4 416.1 279C407.6 269.7 392.4 269.7 383 279L344 318.1V184C344 170.7 333.3 160 320 160C306.7 160 296 170.7 296 184V318.1L256.1 279C247.6 269.7 232.4 269.7 223 279C213.7 288.4 213.7 303.6 223 312.1L303 392.1z"
-                    />
-                  </svg>
-                </div>
-              </a>
-              <a
-                :href="
-                  getIconSrc(icon.name, selectedVariant, 'png', 'wide').value
-                "
-                class="uids-button"
-                v-if="getVariantFormat(selectedVariant, 'png')"
-                download
-              >
-                <div class="uids-button__inner">
-                  <span>PNG (16:9)</span>
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">
-                    <!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
-                    <path
-                      d="M144 480C64.47 480 0 415.5 0 336C0 273.2 40.17 219.8 96.2 200.1C96.07 197.4 96 194.7 96 192C96 103.6 167.6 32 256 32C315.3 32 367 64.25 394.7 112.2C409.9 101.1 428.3 96 448 96C501 96 544 138.1 544 192C544 204.2 541.7 215.8 537.6 226.6C596 238.4 640 290.1 640 352C640 422.7 582.7 480 512 480H144zM303 392.1C312.4 402.3 327.6 402.3 336.1 392.1L416.1 312.1C426.3 303.6 426.3 288.4 416.1 279C407.6 269.7 392.4 269.7 383 279L344 318.1V184C344 170.7 333.3 160 320 160C306.7 160 296 170.7 296 184V318.1L256.1 279C247.6 269.7 232.4 269.7 223 279C213.7 288.4 213.7 303.6 223 312.1L303 392.1z"
-                    />
-                  </svg>
-                </div>
-              </a>
-            </div>
-          </div>
         </div>
         <div class="modal__preview-actions">
-          <h1 class="modal__heading">{{ icon.name }}</h1>
-          <p class="text-center">Select a variant:</p>
-          <div class="modal__icon-variants-wrapper">
-            <div
-              v-for="value in variantFormats"
-              class="icon-preview icon-preview--small"
-              :class="[
-                { active: selectedVariant == value.variant },
-                'icon-preview--' + value.variant,
-              ]"
-              :key="value.variant"
-            >
-              <Icon
-                class="icon-preview__img"
-                :icon="icon.name"
-                :variant="value.variant"
-                @click="changeSelectedVariant(value.variant)"
-              />
+          <div>
+            <h1 class="modal__heading">{{ icon.name }}</h1>
+            <p class="text-center">Select a variant:</p>
+            <div class="modal__icon-variants-wrapper">
+              <div
+                v-for="value in variantFormats"
+                class="icon-preview icon-preview--small"
+                :class="[
+                  { active: selectedVariant == value.variant },
+                  'icon-preview--' + value.variant,
+                ]"
+                :key="value.variant"
+              >
+                <Icon
+                  class="icon-preview__img"
+                  :icon="icon.name"
+                  :variant="value.variant"
+                  @click="changeSelectedVariant(value.variant)"
+                />
+              </div>
             </div>
           </div>
         </div>
+      </div>
+      <div class="icon-preview__download">
+        <a
+          :href="getIconSrc(icon.name, selectedVariant, 'svg').value"
+          class="uids-button"
+          v-if="getVariantFormat(selectedVariant, 'svg')"
+          download
+        >
+          <div class="uids-button__inner">
+            <span>SVG</span>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">
+              <!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+              <path
+                d="M144 480C64.47 480 0 415.5 0 336C0 273.2 40.17 219.8 96.2 200.1C96.07 197.4 96 194.7 96 192C96 103.6 167.6 32 256 32C315.3 32 367 64.25 394.7 112.2C409.9 101.1 428.3 96 448 96C501 96 544 138.1 544 192C544 204.2 541.7 215.8 537.6 226.6C596 238.4 640 290.1 640 352C640 422.7 582.7 480 512 480H144zM303 392.1C312.4 402.3 327.6 402.3 336.1 392.1L416.1 312.1C426.3 303.6 426.3 288.4 416.1 279C407.6 269.7 392.4 269.7 383 279L344 318.1V184C344 170.7 333.3 160 320 160C306.7 160 296 170.7 296 184V318.1L256.1 279C247.6 269.7 232.4 269.7 223 279C213.7 288.4 213.7 303.6 223 312.1L303 392.1z"
+              />
+            </svg>
+          </div>
+        </a>
+        <a
+          :href="getIconSrc(icon.name, selectedVariant, 'png', 'square').value"
+          class="uids-button"
+          v-if="getVariantFormat(selectedVariant, 'png')"
+          download
+        >
+          <div class="uids-button__inner">
+            <span>PNG (1:1)</span>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">
+              <!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+              <path
+                d="M144 480C64.47 480 0 415.5 0 336C0 273.2 40.17 219.8 96.2 200.1C96.07 197.4 96 194.7 96 192C96 103.6 167.6 32 256 32C315.3 32 367 64.25 394.7 112.2C409.9 101.1 428.3 96 448 96C501 96 544 138.1 544 192C544 204.2 541.7 215.8 537.6 226.6C596 238.4 640 290.1 640 352C640 422.7 582.7 480 512 480H144zM303 392.1C312.4 402.3 327.6 402.3 336.1 392.1L416.1 312.1C426.3 303.6 426.3 288.4 416.1 279C407.6 269.7 392.4 269.7 383 279L344 318.1V184C344 170.7 333.3 160 320 160C306.7 160 296 170.7 296 184V318.1L256.1 279C247.6 269.7 232.4 269.7 223 279C213.7 288.4 213.7 303.6 223 312.1L303 392.1z"
+              />
+            </svg>
+          </div>
+        </a>
+        <a
+          :href="getIconSrc(icon.name, selectedVariant, 'png', 'wide').value"
+          class="uids-button"
+          v-if="getVariantFormat(selectedVariant, 'png')"
+          download
+        >
+          <div class="uids-button__inner">
+            <span>PNG (16:9)</span>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">
+              <!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+              <path
+                d="M144 480C64.47 480 0 415.5 0 336C0 273.2 40.17 219.8 96.2 200.1C96.07 197.4 96 194.7 96 192C96 103.6 167.6 32 256 32C315.3 32 367 64.25 394.7 112.2C409.9 101.1 428.3 96 448 96C501 96 544 138.1 544 192C544 204.2 541.7 215.8 537.6 226.6C596 238.4 640 290.1 640 352C640 422.7 582.7 480 512 480H144zM303 392.1C312.4 402.3 327.6 402.3 336.1 392.1L416.1 312.1C426.3 303.6 426.3 288.4 416.1 279C407.6 269.7 392.4 269.7 383 279L344 318.1V184C344 170.7 333.3 160 320 160C306.7 160 296 170.7 296 184V318.1L256.1 279C247.6 269.7 232.4 269.7 223 279C213.7 288.4 213.7 303.6 223 312.1L303 392.1z"
+              />
+            </svg>
+          </div>
+        </a>
       </div>
       <div class="tags">
         <span
@@ -194,16 +190,30 @@ function closeModal(currentCategory, currentSearchTerm) {
 
 <style lang="scss">
 .modal {
-  width: 75vw;
+  height: 100vh;
+  width: 75%;
+  overflow-y: scroll;
   padding: 30px;
   padding-top: 20px;
-  margin: 100px auto;
+  margin: 20px auto;
   background: #fff;
   border-radius: 4px;
   border: 1px solid #ccc;
 
+  @media only screen and (min-width: 768px) {
+    margin: 100px auto;
+
+    height: auto;
+  }
+
+  @media only screen and (min-width: 1024px) {
+    width: 75vw;
+  }
   @media only screen and (min-width: 1280px) {
-    width: 50vw;
+    width: 65vw;
+  }
+  @media only screen and (min-width: 1440px) {
+    width: 60vw;
   }
   &__backdrop {
     top: 0;
@@ -218,7 +228,8 @@ function closeModal(currentCategory, currentSearchTerm) {
   &__heading {
     text-align: center;
     line-height: 1;
-    margin: 0;
+    margin-top: 0;
+    margin-bottom: 20px;
     padding: 0;
     display: grid;
     align-self: center;
@@ -246,11 +257,11 @@ function closeModal(currentCategory, currentSearchTerm) {
 
   &__icon-preview-wrapper {
     display: grid;
-
     grid-gap: 10px;
     margin: 0 auto;
+    align-items: center;
 
-    @media only screen and (min-width: 760px) {
+    @media only screen and (min-width: 768px) {
       grid-template-columns: repeat(2, 1fr);
     }
   }
@@ -259,7 +270,7 @@ function closeModal(currentCategory, currentSearchTerm) {
     display: grid;
     p {
       text-align: center;
-      margin: 0;
+      margin-bottom: 10px;
       align-self: end;
     }
   }
@@ -281,7 +292,12 @@ function closeModal(currentCategory, currentSearchTerm) {
 
   &__img {
     display: block;
-    width: 100%;
+    width: 65%;
+    margin: auto;
+
+    @media only screen and (min-width: 760px) {
+      width: 100%;
+    }
   }
 
   &--small {
@@ -293,8 +309,11 @@ function closeModal(currentCategory, currentSearchTerm) {
     border-color: #ffcd00;
   }
   &__download {
-    margin-top: 20px;
+    margin-top: 40px;
     text-align: center;
+    .uids-button {
+      margin-right: 5px;
+    }
   }
 }
 
@@ -307,6 +326,7 @@ function closeModal(currentCategory, currentSearchTerm) {
 }
 
 .tags {
-  margin-top: 30px;
+  margin-top: 20px;
+  text-align: center;
 }
 </style>

--- a/src/components/IconModal.vue
+++ b/src/components/IconModal.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="modal__backdrop"
-    @click.self="closeModal(currentCategory, currentSearchTerm)"
-  >
+  <div class="modal__backdrop" @click.self="closeModal()">
     <div class="modal">
       <div class="modal__actions">
         <svg
@@ -148,6 +145,12 @@ const emit = defineEmits(["closeModal"]);
 
 selectedVariant.value = props.variant;
 
+//Close modal upon pressing Esc
+document.addEventListener("keydown", function (event) {
+  if (event.key === "Escape") {
+    closeModal();
+  }
+});
 // Necessary to map which formats go with variants
 // since we don't provide all formats for all variants.
 const variantFormats = [
@@ -188,15 +191,14 @@ function changeSelectedVariant(variant) {
   selectedVariant.value = variant;
 }
 
-function closeModal(currentCategory, currentSearchTerm) {
-  emit("closeModal", currentCategory, currentSearchTerm);
+function closeModal() {
+  emit("closeModal");
 }
 </script>
 
 <style lang="scss">
 .modal {
   width: 75%;
-
   padding: 30px;
   padding-top: 20px;
   margin: 20px auto;
@@ -205,7 +207,6 @@ function closeModal(currentCategory, currentSearchTerm) {
   border: 1px solid #ccc;
 
   &__body {
-    //height: 80vh;
     max-height: calc(100vh - 200px);
     overflow-y: auto;
   }
@@ -238,11 +239,14 @@ function closeModal(currentCategory, currentSearchTerm) {
   &__heading {
     text-align: center;
     line-height: 1;
-    margin-top: 0;
+    margin-top: 20px;
     margin-bottom: 20px;
     padding: 0;
     display: grid;
     align-self: center;
+    @media only screen and (min-width: 768px) {
+      margin-top: 0;
+    }
   }
 
   &__actions {
@@ -319,10 +323,11 @@ function closeModal(currentCategory, currentSearchTerm) {
     border-color: #ffcd00;
   }
   &__download {
-    margin-top: 40px;
+    margin-top: 20px;
     text-align: center;
     .uids-button {
       margin-right: 5px;
+      margin-bottom: 5px;
     }
   }
 }


### PR DESCRIPTION
Resolves #36
This PR makes the following adjustments to the Icon modal preview:

- Icon modal is now much more mobile friendly (screenshot below)
  - Mobile: Icon modal is scrollable if content overflows vertically
  - Mobile: Button groups are now just buttons
- Escape key closes modal when open
- `<body>` element is no longer scrollable when modal is open


<img width="432" alt="Screen Shot 2022-06-08 at 8 56 00 AM" src="https://user-images.githubusercontent.com/472923/172634755-1d9fc854-da14-4ef4-8728-19b0c95cf4e0.png">

