### PR TITLE
Fixed icon preview active class that was in <style> but not used properly in markup

### DIFF
--- a/src/components/IconModal.vue
+++ b/src/components/IconModal.vue
@@ -33,7 +33,9 @@
                   v-for="value in variantFormats"
                   class="icon-preview icon-preview--small"
                   :class="[
-                    { active: selectedVariant == value.variant },
+                    {
+                      'icon-preview--active': selectedVariant == value.variant,
+                    },
                     'icon-preview--' + value.variant,
                   ]"
                   :key="value.variant"
@@ -54,7 +56,8 @@
             <a
               :href="getIconSrc(icon.name, selectedVariant, 'svg').value"
               class="uids-button"
-              v-if="getVariantFormat(selectedVariant, 'svg')">
+              v-if="getVariantFormat(selectedVariant, 'svg')"
+            >
               <div class="uids-button__inner">
                 <span>SVG</span>
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">


### PR DESCRIPTION
This PR fixes a CSS class rename from `.active` to `.icon-preview--active` that was incomplete. I forgot to add the appropriate markup to the template.

