### PR TITLE
Ensure that @setCurrentSearchTerm is defined as a prop on router-view in order for search terms to be linked to the input field within the view

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -38,7 +38,11 @@
         />
       </div>
 
-      <router-view @openModal="openModal" :currentVariant="currentVariant" />
+      <router-view
+        @openModal="openModal"
+        @setCurrentSearchTerm="setCurrentSearchTerm"
+        :currentVariant="currentVariant"
+      />
     </main>
   </div>
 


### PR DESCRIPTION
Resolves #44 

At some point I removed this prop that's passed via the `<router-view>` element.

How to test:

1. Click any icon in any view (category/home/doesn't matter)
2. Click on a tag ("#academics" for example)
3. Note that "academics" (or whichever tag you clicked) is in the search bar as expected.