### PR TITLE
Cardlike borders across the board

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -92,7 +92,7 @@ a {
 }
 
 .toolbar {
-  padding: 15px 0;
+  padding: 10px 0;
   background-color: #f5f5f5de;
   backdrop-filter: blur(5px);
 

--- a/src/components/IconList.vue
+++ b/src/components/IconList.vue
@@ -44,13 +44,12 @@ function openModal(icon) {
 .icon-list {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  grid-gap: 5px;
+  grid-gap: 10px;
   @media only screen and (min-width: 760px) {
     grid-template-columns: repeat(3, 1fr);
   }
   @media only screen and (min-width: 1280px) {
     grid-template-columns: repeat(6, 1fr);
-    grid-gap: 10px;
   }
   @media only screen and (min-width: 1440px) {
     grid-template-columns: repeat(7, 1fr);
@@ -61,10 +60,9 @@ function openModal(icon) {
     padding-bottom: 15px;
     padding-left: 30px;
     padding-right: 30px;
-    border-radius: 3px;
     display: block;
     text-decoration: none;
-    border: 2px solid #eee;
+    border: 1px solid #ccc;
     cursor: pointer;
 
     img {

--- a/src/components/IconModal.vue
+++ b/src/components/IconModal.vue
@@ -207,7 +207,6 @@ function closeModal() {
   padding-top: 20px;
   margin: 20px auto;
   background: #fff;
-  border-radius: 4px;
   border: 1px solid #ccc;
 
   &__body {
@@ -303,8 +302,7 @@ function closeModal() {
 
 .icon-preview {
   padding: 10%;
-  border: 2px solid #eee;
-  border-radius: 4px;
+  border: 1px solid #ccc;
   background-color: white;
   background: repeating-conic-gradient(#f1f1f1 0% 25%, transparent 0% 50%) 50% /
     50px 50px;
@@ -319,7 +317,7 @@ function closeModal() {
   }
 
   &--small {
-    border: 2px solid #eee;
+    border: 1px solid #ccc;
     background: #fff;
     cursor: pointer;
   }


### PR DESCRIPTION
After starting on work implementing the UIDS button component, I'm realizing that the inconsistency of the border radius isn't really desirable despite my earlier reservations.

This PR gives the icon buttons (and related borders, e.g., the icon modal previews) a border radius of 1px. colored with `#ccc` in order to more closely match the UIDS cards. 

The following screenshots include changes from the [`uids_buttons` branch](https://github.com/uiowa/brand-icon-browser/tree/uids-buttons) in order to demonstrate how the borders look more consistent, however the buttons aren't fully implemented in this branch yet.

<img width="1488" alt="Screen Shot 2022-06-20 at 10 36 45 AM" src="https://user-images.githubusercontent.com/472923/174636663-07c63e8d-3708-409e-96d1-24c170a03be7.png">

<img width="1488" alt="Screen Shot 2022-06-20 at 10 37 28 AM" src="https://user-images.githubusercontent.com/472923/174636778-cc49beba-85a8-4113-acbb-48c245c96f09.png">



