### PR TITLE
ensure that 404.html's pathSegmentsToKeep variable is set properly

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -22,7 +22,7 @@
       // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
       // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
       // Otherwise, leave pathSegmentsToKeep as 0.
-      var pathSegmentsToKeep = 1;
+      var pathSegmentsToKeep = 0;
 
       var l = window.location;
       l.replace(


### PR DESCRIPTION
This prevents some strange redirects. I forgot to set this properly after changing deployment target from `uiowa.github.io/brand-icon-browser` to `icons.brand.uiowa.edu`.