### PR TITLE
Set icon image height and width to be explicit to help with reflows/jitters

### DIFF
--- a/src/components/CategoryListItem.vue
+++ b/src/components/CategoryListItem.vue
@@ -70,6 +70,7 @@ function scrollToTop() {
   &__icon {
     display: block;
     align-self: center;
+    width: 30px;
     height: 30px;
     grid-column: span 1;
   }

--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -7,6 +7,8 @@
     :alt="icon"
     loading="lazy"
     :class="variant"
+    height="100"
+    width="100"
   />
 </template>
 
@@ -17,6 +19,8 @@ const props = defineProps({
   icon: String,
   variant: String,
   format: String,
+  height: String,
+  width: String
 });
 </script>
 

--- a/src/components/IconList.vue
+++ b/src/components/IconList.vue
@@ -8,8 +8,10 @@
       :to="{ hash: '#' + icon.name }"
       @click="openModal(icon)"
     >
-      <Icon :icon="icon.name" :variant="variant" />
-      <span class="icon-list__label">{{ icon.name }}</span>
+      <div class="icon-list__button-inner">
+        <Icon :icon="icon.name" :variant="variant" />
+        <span class="icon-list__label">{{ icon.name }}</span>
+      </div>
     </router-link>
   </div>
   <div class="content text-center" v-if="icons.length == 0">
@@ -56,17 +58,14 @@ function openModal(icon) {
   }
   &__button {
     background: #fff;
-    padding-top: 30px;
-    padding-bottom: 15px;
-    padding-left: 30px;
-    padding-right: 30px;
+    
     display: block;
     text-decoration: none;
     border: 1px solid #ccc;
     cursor: pointer;
 
     img {
-      height: 80px;
+      padding: 10px;
       margin: 0 auto;
       display: block;
     }
@@ -76,12 +75,18 @@ function openModal(icon) {
     }
   }
 
+
+  &__button-inner{
+    padding: 20px;
+  }
+
   &__label {
     font-size: 0.8rem;
     text-align: center;
     line-height: 1;
     display: block;
-    padding: 15px 0;
+    padding-top: 5px;
+    padding-bottom: 15px;
   }
 }
 </style>

--- a/src/components/IconModal.vue
+++ b/src/components/IconModal.vue
@@ -45,6 +45,7 @@
                     :icon="icon.name"
                     :variant="value.variant"
                     @click="changeSelectedVariant(value.variant)"
+
                   />
                 </div>
               </div>


### PR DESCRIPTION
Partially resolves https://github.com/uiowa/brand-icon-browser/issues/14

This PR gives the `<Icon>` element's rendered `<img>` element explicit `height` and `width` attributes in order to help prevent reflows/jittering in some cases (e.g. when opening an `<IconModal>` component).