### PR TITLE
Ensure we're looking for an exact match in the icon name in a category instead of a 'includes'-type check

### DIFF
--- a/src/views/CategoryView.vue
+++ b/src/views/CategoryView.vue
@@ -47,17 +47,17 @@ const icons = computed(() => {
 
   // Get all icon names under a category, then get their objects.
   // @todo This needs to be optimized...
-  iconNames.forEach((element) =>
+  iconNames.forEach((iconName) =>
     iconObjects.icons.push(
       iconsData.icons.filter(function (icon) {
-        return icon.name.includes(element);
+        return icon.name == iconName;
       })
     )
   );
 
   iconArray = iconObjects.icons.flat();
-  iconArray.forEach((item) => {
-    iconSet.add(item);
+  iconArray.forEach((icon) => {
+    iconSet.add(icon);
   });
 
   iconsFiltered = [...iconSet];


### PR DESCRIPTION
Resolves #54

Previously we were erroneously looping through and filtering icons that had a partial match in the icon name instead of an exact match and were displaying icons like `hospital-bill-payment` and `hospital-bill-checklist` when we only wanted to see `hospital`.

This PR changes the filter to an exact match. Thanks again @sondracue! 

## How to Test

- Check out this branch
- Click the "Campus Buildings" category
- Note that `hospital-bill`, `hospital-bill-checklist`, `hospital-bill-payment`, `hospital-bill-question` are now gone from the icon list. 