### PR TITLE
Move close button to the right in IconModal

### DIFF
--- a/src/components/IconModal.vue
+++ b/src/components/IconModal.vue
@@ -253,20 +253,11 @@ function closeModal() {
 
   &__actions {
     align-self: end;
-    text-align: left;
+    text-align: right;
     margin-bottom: 10px;
     margin-top: 0;
     svg {
       width: 15px;
-      cursor: pointer;
-    }
-    button {
-      color: #333;
-      padding: 8px;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-      text-decoration: none;
-      background: white;
       cursor: pointer;
     }
   }


### PR DESCRIPTION
As mentioned by @joewhitsitt in https://github.com/uiowa/brand-icon-browser/issues/2#issuecomment-1164597652, for consistency's sake, this PR moves the "X" (close button) to the top-right instead of the top-left.

<img width="892" alt="Screen Shot 2022-06-24 at 12 33 20 PM" src="https://user-images.githubusercontent.com/472923/175612865-c6f178bc-bdc0-4d73-bdc3-53bce148c0ab.png">

