### PR TITLE
Fixed uiowa-brand-icons dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "jsdom": "^20.0.0",
                 "sharp": "^0.30.5",
                 "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#f451312",
+                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#2be8489",
                 "vue": "^3.2.13",
                 "vue-router": "^4.0.3",
                 "vue-toggle-component": "^1.0.16"
@@ -10215,7 +10215,7 @@
         },
         "node_modules/uiowa-brand-icons": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#f933b40261983d7a5828bf6949ba263d176befed"
+            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#2be84899567b3341af3f9986859c3a4e66a0b715"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -18832,8 +18832,8 @@
             }
         },
         "uiowa-brand-icons": {
-            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#f933b40261983d7a5828bf6949ba263d176befed",
-            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#f451312"
+            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#2be84899567b3341af3f9986859c3a4e66a0b715",
+            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#2be8489"
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "jsdom": "^20.0.0",
         "sharp": "^0.30.5",
         "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-        "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#f451312",
+        "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#2be8489",
         "vue": "^3.2.13",
         "vue-router": "^4.0.3",
         "vue-toggle-component": "^1.0.16"


### PR DESCRIPTION
When merging the `uids-buttons` branch into `main`, I accidentally transposed the commit hash from another dependency in `package.json` and caused builds to fail in other branches when `npm install` or `npm update` was ran.

This PR corrects the `uiowa-brand-icons` dependency to [`2be8489`](https://github.com/uiowa/brand-icons/commit/2be84899567b3341af3f9986859c3a4e66a0b715), the latest merged version of the Brand Icons.