### PR TITLE
Added Antonio to Google Fonts <link> tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title><%= htmlWebpackPlugin.options.title %></title>
      <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/js/all.min.js" integrity="sha512-6PM0qYu5KExuNcKt5bURAoT6KCThUmHRewN3zUFNaoI6Di7XJPTMoT6K0nsagZKk2OB4L7E3q1uQKHNHd4stIQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto Condensed:regular,bold|Roboto:light,regular,bold,italic|Zilla Slab:regular,bold,italic" />
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto Condensed:regular,bold|Roboto:light,regular,bold,italic|Zilla Slab:regular,bold,italic|Antonio:light,regular,bold,italic" />
     
     <% if (process.env.VUE_APP_ENABLE_ANALYTICS === 'true') { %>
     <script async src="https://www.googletagmanager.com/gtag/js?id=<%= process.env.VUE_APP_ANALYTICS_CODE %>"></script>


### PR DESCRIPTION
I tested the Brand Icon Browser on another machine without a local copy of the Antonio font and noticed the buttons were not showing the text in the correct font because we aren't including Antonio via Google Fonts. 

This PR should resolve that.