### PR TITLE
Updated brand icons dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "jsdom": "^20.0.0",
                 "sharp": "^0.30.5",
                 "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#2be8489",
+                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#6f5c33e",
                 "vue": "^3.2.13",
                 "vue-router": "^4.0.3",
                 "vue-toggle-component": "^1.0.16"
@@ -10215,7 +10215,7 @@
         },
         "node_modules/uiowa-brand-icons": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#2be84899567b3341af3f9986859c3a4e66a0b715"
+            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#6f5c33ea3d38d92fb6b75522002023473e9d61e7"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -18832,8 +18832,8 @@
             }
         },
         "uiowa-brand-icons": {
-            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#2be84899567b3341af3f9986859c3a4e66a0b715",
-            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#2be8489"
+            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#6f5c33ea3d38d92fb6b75522002023473e9d61e7",
+            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#6f5c33e"
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "jsdom": "^20.0.0",
         "sharp": "^0.30.5",
         "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-        "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#2be8489",
+        "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#6f5c33e",
         "vue": "^3.2.13",
         "vue-router": "^4.0.3",
         "vue-toggle-component": "^1.0.16"


### PR DESCRIPTION
This updates the brand icons used in the browser to the most recent version, which includes the renaming of the `torii-gate` icon. 