### PR TITLE
Don't scroll to top when opening or closing an icon modal

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -172,8 +172,12 @@ router.beforeEach((to, from, next) => {
     // Add the meta tags to the document head.
     .forEach((tag) => document.head.appendChild(tag));
 
-  // Scroll to the top of the document after changing route
-  scrollToTop();
+  // Scroll to the top of the document after changing route only if it the route's to/from
+  // doesn't contain a hash. Prevents scrolling to top when opening or closing a modal.
+  if (!to.hash && !from.hash) {
+    scrollToTop();
+  }
+
   next();
 });
 


### PR DESCRIPTION
Resolves https://github.com/uiowa/brand-icon-browser/issues/70

## How to test

1. Visit the live site: https://icons.brand.uiowa.edu
2. Stay in the "All Brand Icons" category and scroll down pretty far down the page
3. Click an icon
4. Note that the document scrolls to the top
5. Check out this branch `fix_icon_modal_scroll_behavior` and run `npm run serve`
6.  Follow steps 2-3
7. Note that upon opening the modal and closing the modal that the document stays in the spot you started