### PR TITLE
Renamed icon_download event name to match file_download

### DIFF
--- a/src/components/IconModal.vue
+++ b/src/components/IconModal.vue
@@ -161,7 +161,7 @@ function changeSelectedVariant(variant) {
 }
 
 function trackDownload(icon, variant, format, size) {
-  gtag("event", "icon_downloaded", {
+  gtag("event", "icon_download", {
     icon_name: icon,
     icon_variant: variant,
     icon_format: format,


### PR DESCRIPTION
This follows GA4's naming scheme of not naming things in the past tense. 

Renames `icon_downloaded` to `icon_download`