### PR TITLE
Add copyright notice

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -191,6 +191,7 @@ main {
 }
 .feedback {
   text-align: center;
+  margin-top: 15px;
   margin-bottom: 0;
   font-size: 13px;
   a {
@@ -199,13 +200,13 @@ main {
     padding-right: 10px;
     &:not(:last-child) {
       padding-left: 0;
-      border-right: 1px solid #000;
+      border-right: 1px solid rgba(0, 0, 0, 0.425);
     }
   }
 }
 
 .copyright-container {
-  padding: 10px 0;
+  margin-top: 15px;
   text-align: center;
   font-size: 12px;
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -27,6 +27,9 @@
           >
           <a href="https://uiowa.edu/privacy">Privacy Notice</a>
         </p>
+        <p class="copyright-container">
+          &copy; {{ currentYear }} The University of Iowa
+        </p>
       </div>
     </aside>
 
@@ -201,10 +204,8 @@ main {
   }
 }
 
-.privacy-container {
-  position: sticky;
-  position: -webkit-sticky;
-  bottom: 0;
+.copyright-container {
+  padding: 10px 0;
   text-align: center;
   font-size: 12px;
 }
@@ -227,6 +228,7 @@ const route = useRoute();
 const showModal = ref(false);
 const iconDetails = ref("");
 const currentSearchTerm = ref("");
+var currentYear = new Date().getFullYear();
 
 //If we have an icon in the current URL params, show the icon modal:
 if (window.location.hash) {


### PR DESCRIPTION
Resolves #72 

This PR provides the default copyright footer text (including a dynamic `currentYear` variable) below the download, submit feedback, and privacy notice links. It also adjusts the separator color to match the border of the new `uids-button` component and adjusts the spacing between the download button and the links below it.

Preview:

<img width="314" alt="Screen Shot 2022-07-14 at 3 53 53 PM" src="https://user-images.githubusercontent.com/472923/179084571-320149ed-6f29-4320-ada2-b5e385997274.png">

## How to test

1. `npm run serve`
2. Observe the links in the sidebar
3. (optional) Leave browser window open for an entire year, refresh and see the copyright year update.