### PR TITLE
Remove js/ and css/ folders during main branch preparations task

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -72,8 +72,7 @@ jobs:
       - name: Main branch preparations
         if: github.ref == format('refs/heads/{0}', env.MAIN_BRANCH)
         run: |
-          rm -rf $GITHUB_WORKSPACE/gh-pages/js
-          rm -rf $GITHUB_WORKSPACE/gh-pages/css
+          rm -rf $GITHUB_WORKSPACE/gh-pages/{css,js}
           npm run build --base=/
           cp -a $GITHUB_WORKSPACE/dist/* $GITHUB_WORKSPACE/gh-pages
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -72,6 +72,8 @@ jobs:
       - name: Main branch preparations
         if: github.ref == format('refs/heads/{0}', env.MAIN_BRANCH)
         run: |
+          rm -rf $GITHUB_WORKSPACE/gh-pages/js
+          rm -rf $GITHUB_WORKSPACE/gh-pages/css
           npm run build --base=/
           cp -a $GITHUB_WORKSPACE/dist/* $GITHUB_WORKSPACE/gh-pages
 


### PR DESCRIPTION
Resolves #77 

This PR clears out the `js/` and `css/` folders during the Main branch preparations to prevent excess `app.[hash].js` and `app.[hash].css` file creations leftover from previous builds.

## How to test

This change to a GitHub Actions Workflow has been tested in a forked repo:

Forked repo:
https://github.com/quamsta/brand-icon-browser

Forked `gh-pages.yml`:
https://github.com/quamsta/brand-icon-browser/blob/main/.github/workflows/gh-pages.yml

This repo has a `gh-pages` branch just like the original where its `js/` and `css/` folders have been cleared of all previous versions upon running the modified`.github/workflows/gh-pages.yml` Workflow by making an arbitrary change to `App.vue`:

https://github.com/quamsta/brand-icon-browser/tree/gh-pages/js
https://github.com/quamsta/brand-icon-browser/tree/gh-pages/css

Compare to the original repo's folders which have a plethora of leftover build artifacts:

https://github.com/uiowa/brand-icon-browser/tree/gh-pages/js
https://github.com/uiowa/brand-icon-browser/tree/gh-pages/css

Hypothetically, you could fork this repo and run the build action or make an arbitrary change to a `.vue` file and watch the build process clear out those folders.