### PR TITLE
Alphabetically sort icons in all views

### DIFF
--- a/src/views/CategoryView.vue
+++ b/src/views/CategoryView.vue
@@ -61,7 +61,7 @@ const icons = computed(() => {
   });
 
   iconsFiltered = [...iconSet];
-
+  iconsFiltered.sort((a, b) => a.name.localeCompare(b.name));
   return iconsFiltered;
 });
 

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -17,7 +17,7 @@ const props = defineProps({
   currentVariant: String,
 });
 
-const icons = ref(iconsData.icons);
+const icons = ref(iconsData.icons.sort((a, b) => a.name.localeCompare(b.name)));
 
 function openModal(icon) {
   emit("openModal", icon);

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -73,6 +73,7 @@ function searchData(term) {
   });
 
   let iconsFiltered = [...resultsSet];
+  iconsFiltered.sort((a, b) => a.name.localeCompare(b.name));
 
   if (iconsFiltered.length == 0) {
     gtag("event", "search_no_results", { search_term: term });


### PR DESCRIPTION
Resolves #79 

## How to test

`HomeView` 
1. Load the live version of the site in a browser: https://icons.brand.uiowa.edu
2. Note that `torii-gate` appears near beginning of the list (after `art-building-west`)
3. Pull down this branch, run `npm serve` to open the site locally and note that it now appears correctly sorted further down the list.

`SearchView`
1. Load the live version of the site in a browser: https://icons.brand.uiowa.edu
2. Search for "architecture" in the search bar
3. Note that `torii-gate` appears near beginning of the list (after `art-building-west`)
4. Pull down this branch, run `npm serve` to open the site locally 
5. Search for "architecture" in the search bar and note that it now appears correctly sorted in the list.

`CategoryView`
I don't have a good test case for the sidebar categories having their icons sorted properly, but the same code has been implemented in all views, so hypothetically this should be resolved here too.
