### PR TITLE
Added specific tag clicking event instead of just a search

### DIFF
--- a/src/components/IconModal.vue
+++ b/src/components/IconModal.vue
@@ -115,7 +115,7 @@
                 name: 'Search',
                 params: { term: term },
               }"
-              @click="gtag('event', 'search', [{ search_term: term }])"
+              @click="gtag('event', 'tag_click', [{ term: term }])"
               >#{{ term }}</router-link
             >
           </span>


### PR DESCRIPTION
This differentiates a manually typed search from a click on a tag (e.g. "#diversity") in an `IconModal` 