### PR TITLE
Swapped format and variant labels on download buttons

### DIFF
--- a/src/components/IconModal.vue
+++ b/src/components/IconModal.vue
@@ -81,7 +81,7 @@
                 color="tertiary"
                 size="small"
               >
-                Square (PNG)
+                PNG (Square)
                 <i class="fas fa-download"></i>
               </uids-button>
             </div>
@@ -97,7 +97,7 @@
                 color="tertiary"
                 size="small"
               >
-                Wide (PNG)
+                PNG (Wide)
                 <i class="fas fa-download"></i>
               </uids-button>
             </div>


### PR DESCRIPTION
As per Sondra's request, the button labels have been swapped as follows:

Before:
<img width="418" alt="Screen Shot 2022-08-23 at 1 27 56 PM" src="https://user-images.githubusercontent.com/472923/186236229-2b41c2c8-344f-44dd-a7db-14f132913bdc.png">

After
<img width="426" alt="Screen Shot 2022-08-23 at 1 28 22 PM" src="https://user-images.githubusercontent.com/472923/186236242-7025bd6f-2f0d-4b66-9b1e-63caff66f501.png">
: