### PR TITLE
Updated uiowa-brand-icons dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "jsdom": "^20.0.0",
                 "sharp": "^0.30.5",
                 "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#6f5c33e",
+                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#c8fe9cc",
                 "vue": "^3.2.13",
                 "vue-router": "^4.0.3",
                 "vue-toggle-component": "^1.0.16"
@@ -10215,7 +10215,7 @@
         },
         "node_modules/uiowa-brand-icons": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#6f5c33ea3d38d92fb6b75522002023473e9d61e7"
+            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#c8fe9cca8b67e36128619feaa2bca36d8455bf49"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -18832,8 +18832,8 @@
             }
         },
         "uiowa-brand-icons": {
-            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#6f5c33ea3d38d92fb6b75522002023473e9d61e7",
-            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#6f5c33e"
+            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#c8fe9cca8b67e36128619feaa2bca36d8455bf49",
+            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#c8fe9cc"
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "jsdom": "^20.0.0",
                 "sharp": "^0.30.5",
                 "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#c8fe9cc",
+                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#77e46bc",
                 "vue": "^3.2.13",
                 "vue-router": "^4.0.3",
                 "vue-toggle-component": "^1.0.16"
@@ -10215,7 +10215,7 @@
         },
         "node_modules/uiowa-brand-icons": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#c8fe9cca8b67e36128619feaa2bca36d8455bf49"
+            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#77e46bc2ef997d7132931ce3db63be6b45304bf9"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -18832,8 +18832,8 @@
             }
         },
         "uiowa-brand-icons": {
-            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#c8fe9cca8b67e36128619feaa2bca36d8455bf49",
-            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#c8fe9cc"
+            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#77e46bc2ef997d7132931ce3db63be6b45304bf9",
+            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#77e46bc"
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
         "jsdom": "^20.0.0",
         "sharp": "^0.30.5",
         "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-        "uiowa-brand-icons": 
-"git+https://github.com/uiowa/brand-icons.git#c8fe9cc",
+        "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#77e46bc",
         "vue": "^3.2.13",
         "vue-router": "^4.0.3",
         "vue-toggle-component": "^1.0.16"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "jsdom": "^20.0.0",
         "sharp": "^0.30.5",
         "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-        "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#6f5c33e",
+        "uiowa-brand-icons": 
+"git+https://github.com/uiowa/brand-icons.git#c8fe9cc",
         "vue": "^3.2.13",
         "vue-router": "^4.0.3",
         "vue-toggle-component": "^1.0.16"


### PR DESCRIPTION
Updates the brand icons to the latest version, directly related to this PR:

https://github.com/uiowa/brand-icons/pull/17

> 
> Fixed some misspelled icon names in categories.json that hadn't been updated when icons.json was corrected.
> 
> Also, based on some analytics data, I fixed the following empty/no results errors by tagging some icons with these tags:
> 
> access
> address
> alum
> alumni
> appointment
> athletics
> audience
> author
> class
> contact
> creative
> decision
> electric
> leader
> major
> meet
> meeting
> promote
> protect
> sanitation
> shot
> smile
> story
> success
> sustainability
> target
> vaccination
> visit
> web
> website
> writer