### PR TITLE
Updated brand-icons dependency Added a few tags to childrens-hospital for easier searching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "jsdom": "^20.0.0",
                 "sharp": "^0.30.5",
                 "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#5bc1ee4",
+                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#b761a23",
                 "vue": "^3.2.13",
                 "vue-router": "^4.0.3",
                 "vue-toggle-component": "^1.0.16"
@@ -10239,7 +10239,7 @@
         },
         "node_modules/uiowa-brand-icons": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#5bc1ee4b40ead26b6594b57e8bc9fc60df2bca00"
+            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#b761a236a423e7a297bfd5b83fe37b5a7e07913f"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -18875,8 +18875,8 @@
             }
         },
         "uiowa-brand-icons": {
-            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#5bc1ee4b40ead26b6594b57e8bc9fc60df2bca00",
-            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#5bc1ee4"
+            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#b761a236a423e7a297bfd5b83fe37b5a7e07913f",
+            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#b761a23"
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "jsdom": "^20.0.0",
         "sharp": "^0.30.5",
         "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-        "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#5bc1ee4",
+        "uiowa-brand-icons": 
+"git+https://github.com/uiowa/brand-icons.git#b761a23",
         "vue": "^3.2.13",
         "vue-router": "^4.0.3",
         "vue-toggle-component": "^1.0.16"


### PR DESCRIPTION
Added a few tags to childrens-hospital for easier searching: 

https://github.com/uiowa/brand-icons/commit/b761a236a423e7a297bfd5b83fe37b5a7e07913f