### PR TITLE
Added container around tags in order to track specific events when tags are clicked

### DIFF
--- a/src/components/IconModal.vue
+++ b/src/components/IconModal.vue
@@ -109,15 +109,19 @@
             :key="term.id"
             @click="closeModal()"
           >
-            <router-link
-              class="uids-tag"
-              :to="{
-                name: 'Search',
-                params: { term: term },
-              }"
+            <div
+              class="uids-tag-container"
               @click="gtag('event', 'tag_click', [{ term: term }])"
-              >#{{ term }}</router-link
             >
+              <router-link
+                class="uids-tag"
+                :to="{
+                  name: 'Search',
+                  params: { term: term },
+                }"
+                >#{{ term }}</router-link
+              >
+            </div>
           </span>
         </div>
       </div>

--- a/src/components/UidsTag.vue
+++ b/src/components/UidsTag.vue
@@ -16,4 +16,7 @@ export default {};
   text-decoration: none;
   display: inline-block;
 }
+.uids-tag-container {
+  display: inline-block;
+}
 </style>


### PR DESCRIPTION
I've been looking at analytics and we aren't receiving tag click events (aka clicks on "#athletics" links on the single icon modals) 