### PR TITLE
Updated brand-icons dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "jsdom": "^20.0.0",
                 "sharp": "^0.30.5",
                 "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#b761a23",
+                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#f63f6b8",
                 "vue": "^3.2.13",
                 "vue-router": "^4.0.3",
                 "vue-toggle-component": "^1.0.16"
@@ -10239,7 +10239,7 @@
         },
         "node_modules/uiowa-brand-icons": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#b761a236a423e7a297bfd5b83fe37b5a7e07913f"
+            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#f63f6b8cc5316e5c9715105e19293d86b578be82"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -18875,8 +18875,8 @@
             }
         },
         "uiowa-brand-icons": {
-            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#b761a236a423e7a297bfd5b83fe37b5a7e07913f",
-            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#b761a23"
+            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#f63f6b8cc5316e5c9715105e19293d86b578be82",
+            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#f63f6b8"
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "sharp": "^0.30.5",
         "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
         "uiowa-brand-icons": 
-"git+https://github.com/uiowa/brand-icons.git#b761a23",
+"git+https://github.com/uiowa/brand-icons.git#f63f6b8",
         "vue": "^3.2.13",
         "vue-router": "^4.0.3",
         "vue-toggle-component": "^1.0.16"


### PR DESCRIPTION
Directly tied to: https://github.com/uiowa/brand-icons/commit/f63f6b8cc5316e5c9715105e19293d86b578be82

Adds "engineering" and "engineer" to some icons (no icons were showing up under "engineering" before): 

<img width="1329" alt="Screen Shot 2022-09-02 at 9 20 47 AM" src="https://user-images.githubusercontent.com/472923/188169923-c2dcc09f-08cd-49d4-a5ef-00f4457be3ab.png">
