### PR TITLE
Updated brand icons dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "jsdom": "^20.0.0",
                 "sharp": "^0.30.5",
                 "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#f63f6b8",
+                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#4291855",
                 "vue": "^3.2.13",
                 "vue-router": "^4.0.3",
                 "vue-toggle-component": "^1.0.16"
@@ -10239,7 +10239,7 @@
         },
         "node_modules/uiowa-brand-icons": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#f63f6b8cc5316e5c9715105e19293d86b578be82"
+            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#429185510a6371d7b49f073d5874777e473e09bc"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -18875,8 +18875,8 @@
             }
         },
         "uiowa-brand-icons": {
-            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#f63f6b8cc5316e5c9715105e19293d86b578be82",
-            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#f63f6b8"
+            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#429185510a6371d7b49f073d5874777e473e09bc",
+            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#4291855"
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "jsdom": "^20.0.0",
                 "sharp": "^0.30.5",
                 "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#4291855",
+                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#77c199c",
                 "vue": "^3.2.13",
                 "vue-router": "^4.0.3",
                 "vue-toggle-component": "^1.0.16"
@@ -10239,7 +10239,7 @@
         },
         "node_modules/uiowa-brand-icons": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#429185510a6371d7b49f073d5874777e473e09bc"
+            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#77c199cfed3ab72f8a96847f7beb30a69aff7cce"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -18875,8 +18875,8 @@
             }
         },
         "uiowa-brand-icons": {
-            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#429185510a6371d7b49f073d5874777e473e09bc",
-            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#4291855"
+            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#77c199cfed3ab72f8a96847f7beb30a69aff7cce",
+            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#77c199c"
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "sharp": "^0.30.5",
         "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
         "uiowa-brand-icons": 
-"git+https://github.com/uiowa/brand-icons.git#4291855",
+"git+https://github.com/uiowa/brand-icons.git#77c199c",
         "vue": "^3.2.13",
         "vue-router": "^4.0.3",
         "vue-toggle-component": "^1.0.16"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "sharp": "^0.30.5",
         "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
         "uiowa-brand-icons": 
-"git+https://github.com/uiowa/brand-icons.git#f63f6b8",
+"git+https://github.com/uiowa/brand-icons.git#4291855",
         "vue": "^3.2.13",
         "vue-router": "^4.0.3",
         "vue-toggle-component": "^1.0.16"


### PR DESCRIPTION
Directly tied to https://github.com/uiowa/brand-icons/commit/429185510a6371d7b49f073d5874777e473e09bc

Adds some results for the terms: history, parent, peer, punctuation

<img width="1329" alt="Screen Shot 2022-09-02 at 4 24 20 PM" src="https://user-images.githubusercontent.com/472923/188237363-78a85bf7-aded-4f08-a2f6-17048270585a.png">

<img width="1315" alt="Screen Shot 2022-09-02 at 4 26 07 PM" src="https://user-images.githubusercontent.com/472923/188237499-cb9abc84-7282-4ae0-9fb4-d517c03126bb.png">

<img width="1339" alt="Screen Shot 2022-09-02 at 4 24 24 PM" src="https://user-images.githubusercontent.com/472923/188237361-ddeffc2b-fe35-4b4a-b4bf-d77984dc1ac5.png">

<img width="1326" alt="Screen Shot 2022-09-02 at 4 24 29 PM" src="https://user-images.githubusercontent.com/472923/188237359-dcbde173-9808-41c5-babc-d4b3c48ccfc4.png">