### PR TITLE
updated icons dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "jsdom": "^20.0.0",
                 "sharp": "^0.30.5",
                 "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#b0440f0",
+                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#8804d50",
                 "vue": "^3.2.13",
                 "vue-router": "^4.0.3",
                 "vue-toggle-component": "^1.0.16"
@@ -10239,7 +10239,7 @@
         },
         "node_modules/uiowa-brand-icons": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#b0440f005eadf8e00437c5881375266e648d4904"
+            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#8804d5040cfb778e6a57af7b41d5fc9fae54d364"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -18875,8 +18875,8 @@
             }
         },
         "uiowa-brand-icons": {
-            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#b0440f005eadf8e00437c5881375266e648d4904",
-            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#b0440f0"
+            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#8804d5040cfb778e6a57af7b41d5fc9fae54d364",
+            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#8804d50"
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "jsdom": "^20.0.0",
                 "sharp": "^0.30.5",
                 "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#77c199c",
+                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#b0440f0",
                 "vue": "^3.2.13",
                 "vue-router": "^4.0.3",
                 "vue-toggle-component": "^1.0.16"
@@ -10239,7 +10239,7 @@
         },
         "node_modules/uiowa-brand-icons": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#77c199cfed3ab72f8a96847f7beb30a69aff7cce"
+            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#b0440f005eadf8e00437c5881375266e648d4904"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -18875,8 +18875,8 @@
             }
         },
         "uiowa-brand-icons": {
-            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#77c199cfed3ab72f8a96847f7beb30a69aff7cce",
-            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#77c199c"
+            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#b0440f005eadf8e00437c5881375266e648d4904",
+            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#b0440f0"
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "sharp": "^0.30.5",
         "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
         "uiowa-brand-icons": 
-"git+https://github.com/uiowa/brand-icons.git#77c199c",
+"git+https://github.com/uiowa/brand-icons.git#b0440f0",
         "vue": "^3.2.13",
         "vue-router": "^4.0.3",
         "vue-toggle-component": "^1.0.16"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "sharp": "^0.30.5",
         "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
         "uiowa-brand-icons": 
-"git+https://github.com/uiowa/brand-icons.git#b0440f0",
+"git+https://github.com/uiowa/brand-icons.git#8804d50",
         "vue": "^3.2.13",
         "vue-router": "^4.0.3",
         "vue-toggle-component": "^1.0.16"


### PR DESCRIPTION
Directly tied to https://github.com/uiowa/brand-icons/commits/main

Adds icons to the following search terms based on the Data Studio Report for empty search terms:

- approve
- approved
- change
- circle
- correlation
- crisis
- improvement
- kinnick stadium
- librarian
- light bulb
- market
- morning
- process
- risk
- speak
- stadium
- sunset
- thunder

Adjusted results for

- graph