### PR TITLE
Scroll to results when changing routes to a search or category

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -174,16 +174,30 @@ router.beforeEach((to, from, next) => {
 
   // Scroll to the top of the document after changing route only if it the route's to/from
   // doesn't contain a hash. Prevents scrolling to top when opening or closing a modal.
+  // If target route is a search or category, scroll the toolbar into view instead.
+  // @todo: refactor this a bit.
   if (!to.hash && !from.hash) {
-    scrollToTop();
+    if (to.name == "Search" || to.name == "Category") {
+      scrollToResults();
+    } else {
+      scrollToTop();
+    }
   }
-
   next();
 });
 
 function scrollToTop() {
   var element = document.querySelector(".iowa-bar");
   element.scrollIntoView({
+    block: "start",
+    inline: "nearest",
+  });
+}
+
+function scrollToResults() {
+  var element = document.querySelector(".toolbar");
+  element.scrollIntoView({
+    alignToTop: true,
     block: "start",
     inline: "nearest",
   });


### PR DESCRIPTION
This PR resolves an issue where if you perform a search on mobile, the page will scroll to the top.

## Before:
https://user-images.githubusercontent.com/472923/190504079-b997a74e-698d-4d8c-8b80-2a984d5a196e.mov

## After:
https://user-images.githubusercontent.com/472923/190504164-c0249702-a6d2-43c8-be1d-6c22f2d482ea.mov
