### PR TITLE
Icons dependency update again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "jsdom": "^20.0.0",
                 "sharp": "^0.30.5",
                 "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#e0f5cd2",
+                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#daa4343",
                 "vue": "^3.2.13",
                 "vue-router": "^4.0.3",
                 "vue-toggle-component": "^1.0.16"
@@ -10239,7 +10239,7 @@
         },
         "node_modules/uiowa-brand-icons": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#e0f5cd2d5a704c201ca51d77f6b6049d005a2351"
+            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#daa43431732379b23cda804df3560aee30c2c6e8"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -18875,8 +18875,8 @@
             }
         },
         "uiowa-brand-icons": {
-            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#e0f5cd2d5a704c201ca51d77f6b6049d005a2351",
-            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#e0f5cd2"
+            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#daa43431732379b23cda804df3560aee30c2c6e8",
+            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#daa4343"
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "jsdom": "^20.0.0",
                 "sharp": "^0.30.5",
                 "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#8804d50",
+                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#e0f5cd2",
                 "vue": "^3.2.13",
                 "vue-router": "^4.0.3",
                 "vue-toggle-component": "^1.0.16"
@@ -10239,7 +10239,7 @@
         },
         "node_modules/uiowa-brand-icons": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#8804d5040cfb778e6a57af7b41d5fc9fae54d364"
+            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#e0f5cd2d5a704c201ca51d77f6b6049d005a2351"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -18875,8 +18875,8 @@
             }
         },
         "uiowa-brand-icons": {
-            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#8804d5040cfb778e6a57af7b41d5fc9fae54d364",
-            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#8804d50"
+            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#e0f5cd2d5a704c201ca51d77f6b6049d005a2351",
+            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#e0f5cd2"
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "sharp": "^0.30.5",
         "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
         "uiowa-brand-icons": 
-"git+https://github.com/uiowa/brand-icons.git#8804d50",
+"git+https://github.com/uiowa/brand-icons.git#e0f5cd2",
         "vue": "^3.2.13",
         "vue-router": "^4.0.3",
         "vue-toggle-component": "^1.0.16"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "sharp": "^0.30.5",
         "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
         "uiowa-brand-icons": 
-"git+https://github.com/uiowa/brand-icons.git#e0f5cd2",
+"git+https://github.com/uiowa/brand-icons.git#daa4343",
         "vue": "^3.2.13",
         "vue-router": "^4.0.3",
         "vue-toggle-component": "^1.0.16"


### PR DESCRIPTION
I forgot to commit the latest dependency update in the last PR (https://github.com/uiowa/brand-icon-browser/pull/98) 

This should be the correct PR for these items:

> This updates the uiowa-brand-icons dependency to the latest version and includes search results for the following terms:
> 
> achieve
> achievement
> analytics
> belonging
> biopsy
> communicate
> destination
> faculty
> funding
> infect
> infection
> progress