### PR TITLE
Top links

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,21 +5,21 @@
     </h1>
     <nav
       role="navigation"
-      aria-labelledby="block-uids-base-toplinks-menu"
-      id="block-uids-base-toplinks"
-      class="menu--top nav block block-menu navigation menu--top-links"
+      aria-labelledby="toplinks-menu"
+      id="toplinks"
+      class="menu--top"
     >
-      <h2 class="visually-hidden" id="block-uids-base-toplinks-menu">
+      <h2 class="visually-hidden" id="toplinks-menu">
         Top links
       </h2>
 
       <ul class="menu">
-        <li class="menu-item">
+        <li>
           <a href="https://brand.uiowa.edu/graphic-elements#iconography"
             >Using Brand Icons</a
           >
         </li>
-        <li class="menu-item">
+        <li>
           <a href="https://brand.uiowa.edu">Brand Manual</a>
         </li>
       </ul>

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@
           >
         </li>
         <li class="menu-item">
-          <a href="https://brand.uiowa.edu">Brand manual</a>
+          <a href="https://brand.uiowa.edu">Brand Manual</a>
         </li>
       </ul>
     </nav>

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,18 +9,13 @@
       id="toplinks"
       class="menu--top"
     >
-      <h2 class="visually-hidden" id="toplinks-menu">
-        Top links
-      </h2>
+      <h2 class="visually-hidden" id="toplinks-menu">Top links</h2>
 
       <ul class="menu">
         <li>
           <a href="https://brand.uiowa.edu/graphic-elements#iconography"
-            >Using Brand Icons</a
+            >Icon Usage</a
           >
-        </li>
-        <li>
-          <a href="https://brand.uiowa.edu">Brand Manual</a>
         </li>
       </ul>
     </nav>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,29 @@
 <template>
-  <uids-brand-bar height="narrow">
+  <uids-brand-bar height="narrow" class="iowa-bar--full iowa-bar horizontal">
     <h1 class="site-name">
       <router-link :to="{ name: 'Home' }">Icon Browser</router-link>
     </h1>
+    <nav
+      role="navigation"
+      aria-labelledby="block-uids-base-toplinks-menu"
+      id="block-uids-base-toplinks"
+      class="menu--top nav block block-menu navigation menu--top-links"
+    >
+      <h2 class="visually-hidden" id="block-uids-base-toplinks-menu">
+        Top links
+      </h2>
+
+      <ul class="menu">
+        <li class="menu-item">
+          <a href="https://brand.uiowa.edu/graphic-elements#iconography"
+            >Using Brand Icons</a
+          >
+        </li>
+        <li class="menu-item">
+          <a href="https://brand.uiowa.edu">Brand manual</a>
+        </li>
+      </ul>
+    </nav>
   </uids-brand-bar>
 
   <div class="wrapper" id="main-wrapper">
@@ -67,6 +88,8 @@
 @import "node_modules/uids/src/components/logo/logo.scss";
 @import "node_modules/uids/src/components/brand-bar/brand-bar.scss";
 @import "node_modules/uids/src/components/button/button.scss";
+@import "~/src/scss/components/top-menu.scss";
+
 body {
   margin: 0;
   font-family: Roboto, sans-serif;

--- a/src/scss/components/top-menu.scss
+++ b/src/scss/components/top-menu.scss
@@ -1,0 +1,163 @@
+.iowa-bar__container {
+    max-width: 1550px;
+}
+
+@media(min-width: 84.375em) {
+    .iowa-bar--full.horizontal .menu--top,
+    .iowa-bar--full.mega .menu--top,
+    .iowa-bar--full.toggle .menu--top {
+        margin-top: 4px;
+        justify-content: flex-end;
+        margin-left: auto;
+    }
+}
+
+@media(min-width: 768px) {
+    .nav {
+        align-items: center;
+        display: flex;
+    }
+    .menu-wrapper .menu,
+    .nav .menu {
+        list-style-type: none;
+        padding: 0;
+        margin: 0;
+    }
+    .menu--top.nav {
+        margin-top: 9px;
+    }
+    .menu--top.nav {
+        margin-top: 7px;
+        position: absolute;
+        z-index: 2;
+        right: 96px;
+        top: 0;
+        display: block;
+    }
+}
+@media(min-width: 855px) and(min-width: 84.375em) {
+    .iowa-bar--full.horizontal .menu--top .menu li a,
+    .iowa-bar--full.mega .menu--top .menu li a,
+    .iowa-bar--full.toggle .menu--top .menu li a {
+        padding: 0.325rem 1.05rem;
+        font-weight: 300;
+    }
+}
+
+@media(min-width: 855px) {
+    .iowa-bar--full.horizontal .site-name,
+    .iowa-bar--full.mega .site-name,
+    .iowa-bar--full.toggle .site-name {
+        margin: 5px 0 0;
+        flex: 0 1 50%;
+        font-weight: 300;
+    }
+    .iowa-bar--full.horizontal .menu--top,
+    .iowa-bar--full.mega .menu--top,
+    .iowa-bar--full.toggle .menu--top {
+        right: -10px;
+        margin-top: 8px;
+        position: relative;
+        align-self: center;
+        justify-content: flex-start;
+    }
+    .iowa-bar--full.horizontal .menu--top,
+    .iowa-bar--full.mega .menu--top,
+    .iowa-bar--full.toggle .menu--top {
+        flex: 0 1 30%;
+        display: flex;
+        justify-content: flex-end;
+        height: 100%;
+    }
+
+    .iowa-bar--full.horizontal .menu--top .menu li a,
+    .iowa-bar--full.mega .menu--top .menu li a,
+    .iowa-bar--full.toggle .menu--top .menu li a {
+        display: block;
+        text-decoration: none;
+        color: #151515;
+        font-size: 1.1rem;
+        position: relative;
+        line-height: 1.3;
+        text-align: center;
+    }
+    .nav.menu--top .menu li a {
+        font-weight: 300;
+    }
+    .iowa-bar--full .menu--top .menu li a {
+        font-size: 1.2rem;
+        padding-right: 1.05rem;
+    }
+    .iowa-bar--full .menu--top .menu li a {
+        font-size: 0.9rem;
+        padding-right: 0;
+    }
+    .menu--top.nav {
+        right: 356px;
+        margin-top: 11px;
+    }
+    .menu--top .menu li a {
+        color: #151515;
+    }
+}
+@media screen and(max-width: 1605px) and(min-width: 855px) {
+    .iowa-bar--full.horizontal .site-name,
+    .iowa-bar--full.mega .site-name,
+    .iowa-bar--full.toggle .site-name {
+        font-size: 2vw;
+        font-weight: 400;
+    }
+}
+@media only screen and(min-width: 0) and(max-width: 854px) {
+    .menu--top.nav {
+        background: #ffcd00;
+        margin-top: 0;
+        position: inherit;
+        padding: 0.75rem 1.25rem;
+    }
+
+    .menu--top.nav .menu li a {
+        color: #151515;
+        padding: 0.325rem 0;
+        font-size: 1rem;
+    }
+
+    .menu--top.nav .menu li:nth-child(2) {
+        margin: 0 25px;
+    }
+
+    .site-name + .menu--top {
+        padding: 0 1.25rem 0.75rem;
+        margin-top: -0.75rem;
+    }
+}
+
+.menu--top .menu li a {
+    padding: 1.05rem;
+    color: #fff;
+}
+.nav .menu {
+    overflow: visible;
+    font-size: 1rem;
+    display: flex;
+}
+
+.nav .menu a,
+.nav .menu span {
+    position: relative;
+    display: inline-block;
+    transition: background 0.8s ease-out;
+    text-decoration: none;
+    color: #151515;
+}
+
+.menu-wrapper .menu > li,
+.nav .menu > li {
+    display: inline-block;
+    list-style-type: none;
+    margin: 0;
+}
+
+.nav.menu--top .menu li a {
+    font-weight: 300;
+}

--- a/src/scss/components/top-menu.scss
+++ b/src/scss/components/top-menu.scss
@@ -2,162 +2,66 @@
     max-width: 1550px;
 }
 
-@media(min-width: 84.375em) {
-    .iowa-bar--full.horizontal .menu--top,
-    .iowa-bar--full.mega .menu--top,
-    .iowa-bar--full.toggle .menu--top {
-        margin-top: 4px;
-        justify-content: flex-end;
-        margin-left: auto;
-    }
-}
-
-@media(min-width: 768px) {
-    .nav {
-        align-items: center;
-        display: flex;
-    }
-    .menu-wrapper .menu,
-    .nav .menu {
-        list-style-type: none;
-        padding: 0;
-        margin: 0;
-    }
-    .menu--top.nav {
-        margin-top: 9px;
-    }
-    .menu--top.nav {
-        margin-top: 7px;
-        position: absolute;
-        z-index: 2;
-        right: 96px;
-        top: 0;
-        display: block;
-    }
-}
-@media(min-width: 855px) and(min-width: 84.375em) {
-    .iowa-bar--full.horizontal .menu--top .menu li a,
-    .iowa-bar--full.mega .menu--top .menu li a,
-    .iowa-bar--full.toggle .menu--top .menu li a {
-        padding: 0.325rem 1.05rem;
-        font-weight: 300;
-    }
-}
-
-@media(min-width: 855px) {
-    .iowa-bar--full.horizontal .site-name,
-    .iowa-bar--full.mega .site-name,
-    .iowa-bar--full.toggle .site-name {
-        margin: 5px 0 0;
-        flex: 0 1 50%;
-        font-weight: 300;
-    }
-    .iowa-bar--full.horizontal .menu--top,
-    .iowa-bar--full.mega .menu--top,
-    .iowa-bar--full.toggle .menu--top {
-        right: -10px;
-        margin-top: 8px;
-        position: relative;
-        align-self: center;
-        justify-content: flex-start;
-    }
-    .iowa-bar--full.horizontal .menu--top,
-    .iowa-bar--full.mega .menu--top,
-    .iowa-bar--full.toggle .menu--top {
-        flex: 0 1 30%;
-        display: flex;
-        justify-content: flex-end;
-        height: 100%;
-    }
-
-    .iowa-bar--full.horizontal .menu--top .menu li a,
-    .iowa-bar--full.mega .menu--top .menu li a,
-    .iowa-bar--full.toggle .menu--top .menu li a {
-        display: block;
-        text-decoration: none;
-        color: #151515;
-        font-size: 1.1rem;
-        position: relative;
-        line-height: 1.3;
-        text-align: center;
-    }
-    .nav.menu--top .menu li a {
-        font-weight: 300;
-    }
-    .iowa-bar--full .menu--top .menu li a {
-        font-size: 1.2rem;
-        padding-right: 1.05rem;
-    }
-    .iowa-bar--full .menu--top .menu li a {
-        font-size: 0.9rem;
-        padding-right: 0;
-    }
-    .menu--top.nav {
-        right: 356px;
-        margin-top: 11px;
-    }
-    .menu--top .menu li a {
-        color: #151515;
-    }
-}
-@media screen and(max-width: 1605px) and(min-width: 855px) {
-    .iowa-bar--full.horizontal .site-name,
-    .iowa-bar--full.mega .site-name,
-    .iowa-bar--full.toggle .site-name {
-        font-size: 2vw;
-        font-weight: 400;
-    }
-}
-@media only screen and(min-width: 0) and(max-width: 854px) {
-    .menu--top.nav {
-        background: #ffcd00;
-        margin-top: 0;
-        position: inherit;
-        padding: 0.75rem 1.25rem;
-    }
-
-    .menu--top.nav .menu li a {
-        color: #151515;
-        padding: 0.325rem 0;
-        font-size: 1rem;
-    }
-
-    .menu--top.nav .menu li:nth-child(2) {
-        margin: 0 25px;
-    }
-
-    .site-name + .menu--top {
-        padding: 0 1.25rem 0.75rem;
-        margin-top: -0.75rem;
-    }
-}
-
 .menu--top .menu li a {
     padding: 1.05rem;
-    color: #fff;
-}
-.nav .menu {
-    overflow: visible;
-    font-size: 1rem;
-    display: flex;
 }
 
-.nav .menu a,
-.nav .menu span {
-    position: relative;
-    display: inline-block;
-    transition: background 0.8s ease-out;
+.menu--top .menu a {
     text-decoration: none;
-    color: #151515;
+    font-weight: 300;
 }
 
-.menu-wrapper .menu > li,
-.nav .menu > li {
+.menu--top .menu > li {
     display: inline-block;
     list-style-type: none;
     margin: 0;
 }
 
-.nav.menu--top .menu li a {
-    font-weight: 300;
+@media(min-width: 855px) and(min-width: 84.375em) {
+    .menu--top .menu li a {
+        padding: 0.325rem 1.05rem;
+    }
+}
+
+@media(min-width: 855px) {
+    .iowa-bar .site-name {
+        margin: 5px 0 0;
+        flex: auto;
+        font-weight: 300;
+    }
+
+    .menu--top {
+        margin-top: 8px;
+        position: relative;
+        align-self: center;
+        flex: auto;
+        display: flex;
+        justify-content: flex-end;
+
+    }
+}
+
+@media screen and(max-width: 1605px) and(min-width: 855px) {
+    .iowa-bar .site-name {
+        font-size: 2vw;
+        font-weight: 400;
+    }
+}
+
+@media only screen and(min-width: 0) and(max-width: 854px) {
+    .menu--top .menu li a {
+        color: #151515;
+        padding: 0.325rem 0;
+        font-size: 1rem;
+    }
+
+    .menu--top .menu li:nth-child(2) {
+        margin: 0 25px;
+    }
+
+    .site-name + .menu--top {
+        background: #ffcd00;
+        padding: 0 1.25rem 0.75rem;
+        margin-top: -0.75rem;
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/uiowa/brand-icon-browser/issues/101.

I ported some of the menu CSS classes from the Drupal theme into: https://github.com/uiowa/brand-icon-browser/blob/feature_top_links/src/scss/components/top-menu.scss

<img width="1596" alt="Screen Shot 2022-10-05 at 11 26 12 AM" src="https://user-images.githubusercontent.com/472923/194112157-687f3e78-be21-4c76-941d-823e322ce814.png">

<img width="846" alt="Screen Shot 2022-10-05 at 11 26 36 AM" src="https://user-images.githubusercontent.com/472923/194112226-a63dec82-c332-401f-810d-829dd946ecd4.png">

Not exactly neat and tidy, but I didn't see anything in UIDS about those top menu links, and figured they may as well be application-specific for now, but could be pulled out and used in UIDS in the future. 

Would be open to feedback on how to clean this up a bit. 