### PR TITLE
Added block-i-banner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "jsdom": "^20.0.0",
                 "sharp": "^0.30.5",
                 "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
-                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#c9aad5c",
+                "uiowa-brand-icons": "git+https://github.com/uiowa/brand-icons.git#2480e8a",
                 "vue": "^3.2.13",
                 "vue-router": "^4.0.3",
                 "vue-toggle-component": "^1.0.16"
@@ -10030,7 +10030,7 @@
         },
         "node_modules/uiowa-brand-icons": {
             "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#c9aad5c6d6ee86d8470d1031122b064e9f998be9"
+            "resolved": "git+ssh://git@github.com/uiowa/brand-icons.git#2480e8a23f08b9baddb703d97bfec66f6209b188"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -18531,8 +18531,8 @@
             }
         },
         "uiowa-brand-icons": {
-            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#c9aad5c6d6ee86d8470d1031122b064e9f998be9",
-            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#c9aad5c"
+            "version": "git+ssh://git@github.com/uiowa/brand-icons.git#2480e8a23f08b9baddb703d97bfec66f6209b188",
+            "from": "uiowa-brand-icons@git+https://github.com/uiowa/brand-icons.git#2480e8a"
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "sharp": "^0.30.5",
         "uids": "git+https://github.com/uiowa/uids.git#d9f64e5",
         "uiowa-brand-icons":
-        "git+https://github.com/uiowa/brand-icons.git#c9aad5c",
+        "git+https://github.com/uiowa/brand-icons.git#2480e8a",
         "vue": "^3.2.13",
         "vue-router": "^4.0.3",
         "vue-toggle-component": "^1.0.16"


### PR DESCRIPTION
# How to test


1. Test the icon by running `npm run build` followed by `npm run serve` to ensure the build succeeds and that the new icon are available on localhost.
2. Look for the block-i-banner in newly added, kids, and academics/research categories.
